### PR TITLE
メッセージ送信機能の非同期通信実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,49 @@
+$(function(){
+  function scroll(){
+    var target = $('.message').last();
+    var position = target.offset().top + $('.messages').scrollTop();
+    $('.messages').animate({scrollTop:position}, 500, 'swing');
+  }
+  function buildHTML(content){
+    var message = content.message ? `${content.message}` : "";
+    var image = content.image ? `<img src=${content.image}>` : "";
+    var html = `<div class="message">
+                  <div class="message__upper-info">
+                    <p class="message__upper-info__talker">
+                    ${content.user_name}
+                    </p>
+                    <p class="message__upper-info__date">
+                    ${content.date}
+                    </p>
+                  </div>
+                  <p class="message__text">
+                  ${message}
+                  </p>
+                  ${image}
+                </div>`
+    return html;
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+       var html = buildHTML(data);
+       $('.messages').append(html);
+       scroll();
+       $('#message_message').val("");
+       $('#message_image').val("");
+    })
+    .fail(function(){
+      alert('メッセージを送信できませんでした！！');
+    })
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,8 +39,7 @@ $(function(){
        var html = buildHTML(data);
        $('.messages').append(html);
        scroll();
-       $('#message_message').val("");
-       $('#message_image').val("");
+       $('#new_message')[0].reset();
     })
     .fail(function(){
       alert('メッセージを送信できませんでした！！');

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.date @message.created_at.in_time_zone('Asia/Tokyo').strftime("%Y/%m/%d(%a) %H:%M")
+json.message @message.message
+json.image @message.image.url

--- a/app/views/shared/_chat.html.haml
+++ b/app/views/shared/_chat.html.haml
@@ -11,7 +11,7 @@
   .messages
     = render partial: 'messages/message', collection: @messages
   .form
-    = form_for [@group, @message], html: {class: 'new_message'} do |f|
+    = form_for [@group, @message], html: {id: 'new_message', class: 'new_message'} do |f|
       .input-box
         = f.text_field :message, class: 'input-box__text', placeholder: 'type a message'
         = f.label :image, class: 'input-box__image' do

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,7 @@ module ChatSpace
     end
 
     config.i18n.default_locale = :ja
+
+    config.action_view.automatically_disable_submit_tag = false
   end
 end


### PR DESCRIPTION
# What
メッセージ送信機能を非同期通信を用いて実装する

# Why
サーバからの応答待ちによるユーザビリティ低下を防ぐため

# gifキャプチャ
メッセージのみ送信
![send-message](https://user-images.githubusercontent.com/48156993/55815181-e3327680-5b2a-11e9-97ed-80c35c35d712.gif)
画像のみ送信
![send-image](https://user-images.githubusercontent.com/48156993/55815188-e62d6700-5b2a-11e9-9569-90e9a0bc3d7b.gif)
メッセージと画像を送信
![send-message-and-image](https://user-images.githubusercontent.com/48156993/55815192-e75e9400-5b2a-11e9-9eca-63d6f27e05fa.gif)
送信エラー
![send-error](https://user-images.githubusercontent.com/48156993/55815199-e9c0ee00-5b2a-11e9-8cda-0bf5cb42f975.gif)



